### PR TITLE
Edit yarn upgrade docs to match implementation

### DIFF
--- a/en/docs/managing-dependencies.md
+++ b/en/docs/managing-dependencies.md
@@ -77,9 +77,7 @@ yarn add package-3@beta
 ### Upgrading a dependency <a class="toc" id="toc-upgrading-a-dependency" href="#toc-upgrading-a-dependency"></a>
 
 ```sh
-yarn upgrade [package]
-yarn upgrade [package]@[version]
-yarn upgrade [package]@[dist-tag]
+yarn upgrade
 ```
 
 This will upgrade your `package.json` and your `yarn.lock` file.


### PR DESCRIPTION
### Overview
`yarn update` doesn't take in arguments i.e. package name and semver numbers. This can be seen [here](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/upgrade.js#L13).

`export const noArguments = true;`

and [here]()

    if (command.noArguments && args.length) {
        reporter.error(reporter.lang('noArguments'));
        reporter.info(getDocsInfo(commandName));
        process.exit(1);
    }

Instead, it upgrades the entire list of packages in `package.json`. The only way of updating a new version of an existing package seems to be 

    yarn add <package-name>@version

I will add a new PR adding the workaround to the docs, as I am not sure whether this is the intended functionality of either commands, and I don't want to mash the two together