### PR TITLE
update docs on updating dependency

### DIFF
--- a/en/docs/usage.md
+++ b/en/docs/usage.md
@@ -27,9 +27,7 @@ yarn add [package]@[tag]
 **Updating a dependency**
 
 ```sh
-yarn upgrade [package]
-yarn upgrade [package]@[version]
-yarn upgrade [package]@[tag]
+yarn add [package]@[version]
 ```
 
 **Removing a dependency**


### PR DESCRIPTION
currently, `yarn upgrade` doesn't take in arguments, so the provided documentation is misleading. The only way to upgrade a particular dependency is using `yarn add <package>@<version>`. This is most likely a bug that needs to be addressed, but until then the documentation needs to reflect this
